### PR TITLE
Scope agent names to creator (fixes #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Messages are JSON: `{id, nick, type, body, ts}`
 ### Commands
 
 ```bash
-./start.sh ~/workspace username    # Full system startup (tmux + agent0 + weechat)
+./start.sh ~/workspace username    # Full system startup (tmux + username:agent0 + weechat)
 ./stop.sh                          # Kill tmux session
 pytest tests/unit/                 # Unit tests (mocked Zenoh, fast)
 pytest -m integration tests/       # Integration tests (real Zenoh peers)
@@ -51,6 +51,7 @@ pytest -m integration tests/       # Integration tests (real Zenoh peers)
 ### Key Constraints
 
 - Channel MCP requires `--dangerously-load-development-channels` flag
-- `agent0` is special — created by start.sh, cannot be stopped via `/agent stop`
+- `{username}:agent0` is the primary agent — created by start.sh, cannot be stopped via `/agent stop`
+- Agent names are scoped to creator: `alice:agent0`, `alice:helper` (separator: `:`)
 - WeeChat callbacks must not block — use deques + timers for async work
 - Zenoh Python + WeeChat .so may conflict — sidecar process is planned

--- a/start.sh
+++ b/start.sh
@@ -46,12 +46,12 @@ tmux new-session -d -s "$SESSION" -x 220 -y 50
 
 # --- Pane 0: Claude Code (agent0) with channel plugin ---
 tmux send-keys -t "$SESSION" \
-  "cd '$WORKSPACE' && AGENT_NAME=agent0 claude \
+  "cd '$WORKSPACE' && AGENT_NAME='$USERNAME:agent0' claude \
     --dangerously-skip-permissions \
     --dangerously-load-development-channels \
     plugin:weechat-channel" Enter
 
-echo -n "  Waiting for agent0..."
+echo -n "  Waiting for $USERNAME:agent0..."
 sleep 5
 echo " done"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,5 +78,5 @@ def mock_zenoh_session():
 
 @pytest.fixture
 def agent_name():
-    """Default agent name for tests."""
-    return "agent0"
+    """Default agent name for tests (scoped to creator per issue #2)."""
+    return "alice:agent0"

--- a/tests/integration/test_channel_bridge.py
+++ b/tests/integration/test_channel_bridge.py
@@ -29,8 +29,8 @@ class TestChannelBridge:
         """Publish a DM and verify the agent's filter logic accepts it."""
         from message import make_dm_pair
 
-        agent_name = "agent0"
-        sender = "alice"
+        agent_name = "alice:agent0"
+        sender = "bob"
         pair = make_dm_pair(agent_name, sender)
         topic = f"wc/dm/{pair}/messages"
 
@@ -69,7 +69,7 @@ class TestChannelBridge:
 
     def test_dm_not_for_agent_ignored(self, zenoh_session):
         """DMs between other users should not be received by agent."""
-        agent_name = "agent0"
+        agent_name = "alice:agent0"
 
         received = []
         def filter_dm(sample):
@@ -85,15 +85,15 @@ class TestChannelBridge:
         )
         time.sleep(0.5)
 
-        # DM between alice and bob — agent0 not involved
+        # DM between bob and carol — alice:agent0 not involved
         msg = json.dumps({
             "id": "other-001",
-            "nick": "alice",
+            "nick": "bob",
             "type": "msg",
-            "body": "hey bob",
+            "body": "hey carol",
             "ts": time.time(),
         })
-        zenoh_session.put("wc/dm/alice_bob/messages", msg)
+        zenoh_session.put("wc/dm/bob_carol/messages", msg)
 
         time.sleep(1.0)
         assert len(received) == 0
@@ -109,7 +109,7 @@ class TestChannelBridge:
         time.sleep(0.5)
 
         # Simulate what the reply tool does
-        agent_name = "agent0"
+        agent_name = "alice:agent0"
         reply_msg = json.dumps({
             "id": os.urandom(8).hex(),
             "nick": agent_name,
@@ -124,5 +124,5 @@ class TestChannelBridge:
             time.sleep(0.1)
 
         assert len(received) == 1
-        assert received[0]["nick"] == "agent0"
+        assert received[0]["nick"] == "alice:agent0"
         assert received[0]["body"] == "Here are the files"

--- a/tests/integration/test_dm_and_room.py
+++ b/tests/integration/test_dm_and_room.py
@@ -21,9 +21,9 @@ def zenoh_session():
 
 
 class TestDmRouting:
-    def test_agent0_receives_own_dm(self, zenoh_session):
-        """Messages to agent0's DM pair are received."""
-        pair = make_dm_pair("agent0", "alice")
+    def test_agent_receives_own_dm(self, zenoh_session):
+        """Messages to alice:agent0's DM pair are received."""
+        pair = make_dm_pair("alice:agent0", "bob")
         topic = f"wc/dm/{pair}/messages"
         received = []
 
@@ -35,7 +35,7 @@ class TestDmRouting:
         time.sleep(0.5)
 
         zenoh_session.put(topic, json.dumps({
-            "id": "r-001", "nick": "alice", "type": "msg",
+            "id": "r-001", "nick": "bob", "type": "msg",
             "body": "hello", "ts": time.time(),
         }))
 
@@ -45,55 +45,55 @@ class TestDmRouting:
 
         assert len(received) == 1
 
-    def test_agent1_does_not_receive_agent0_dm(self, zenoh_session):
-        """agent1 should not receive DMs addressed to agent0."""
-        agent0_pair = make_dm_pair("agent0", "alice")
-        agent0_topic = f"wc/dm/{agent0_pair}/messages"
+    def test_other_agent_does_not_receive_dm(self, zenoh_session):
+        """bob:agent1 should not receive DMs addressed to alice:agent0."""
+        target_pair = make_dm_pair("alice:agent0", "carol")
+        target_topic = f"wc/dm/{target_pair}/messages"
 
-        agent1_received = []
+        other_received = []
 
-        def agent1_filter(sample):
+        def other_filter(sample):
             key = str(sample.key_expr)
             pair = key.split("/")[2]
-            if "agent1" in pair.split("_"):
-                agent1_received.append(True)
+            if "bob:agent1" in pair.split("_"):
+                other_received.append(True)
 
         zenoh_session.declare_subscriber(
-            "wc/dm/*/messages", agent1_filter, background=True
+            "wc/dm/*/messages", other_filter, background=True
         )
         time.sleep(0.5)
 
-        zenoh_session.put(agent0_topic, json.dumps({
-            "id": "r-002", "nick": "alice", "type": "msg",
-            "body": "for agent0 only", "ts": time.time(),
+        zenoh_session.put(target_topic, json.dumps({
+            "id": "r-002", "nick": "carol", "type": "msg",
+            "body": "for alice:agent0 only", "ts": time.time(),
         }))
 
         time.sleep(1.0)
-        assert len(agent1_received) == 0
+        assert len(other_received) == 0
 
 
 class TestRoomMentionFiltering:
     def test_mention_triggers_forwarding(self):
-        """Room message with @agent0 should be forwarded."""
-        body = "@agent0 list files"
-        assert detect_mention(body, "agent0") is True
-        cleaned = clean_mention(body, "agent0")
+        """Room message with @alice:agent0 should be forwarded."""
+        body = "@alice:agent0 list files"
+        assert detect_mention(body, "alice:agent0") is True
+        cleaned = clean_mention(body, "alice:agent0")
         assert cleaned == "list files"
 
     def test_no_mention_not_forwarded(self):
         """Room message without @mention should not be forwarded."""
         body = "hello everyone, nice day"
-        assert detect_mention(body, "agent0") is False
+        assert detect_mention(body, "alice:agent0") is False
 
     def test_wrong_agent_mention_not_forwarded(self):
-        """@agent1 mention should not trigger agent0."""
-        body = "@agent1 do something"
-        assert detect_mention(body, "agent0") is False
+        """@bob:agent1 mention should not trigger alice:agent0."""
+        body = "@bob:agent1 do something"
+        assert detect_mention(body, "alice:agent0") is False
 
     def test_mention_in_room_roundtrip(self, zenoh_session):
         """End-to-end: room message with @mention is received and cleaned."""
         topic = "wc/rooms/general/messages"
-        agent_name = "agent0"
+        agent_name = "alice:agent0"
         forwarded = []
 
         def room_handler(sample):
@@ -111,8 +111,8 @@ class TestRoomMentionFiltering:
         time.sleep(0.5)
 
         zenoh_session.put(topic, json.dumps({
-            "id": "rm-001", "nick": "alice", "type": "msg",
-            "body": "@agent0 what files changed?", "ts": time.time(),
+            "id": "rm-001", "nick": "carol", "type": "msg",
+            "body": "@alice:agent0 what files changed?", "ts": time.time(),
         }))
 
         deadline = time.time() + 2.0

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -35,29 +35,29 @@ class TestAgentCreateLogic:
         assert server["command"] == "uv"
         assert server["env"]["AGENT_NAME"] == name
 
-    def test_agent0_cannot_be_stopped(self):
-        """Verify the stop-agent0 guard logic."""
-        # This tests the condition used in stop_agent()
-        name = "agent0"
-        assert name == "agent0"  # This would trigger the guard
+    def test_primary_agent_cannot_be_stopped(self):
+        """Verify the stop-primary-agent guard logic."""
+        primary = "alice:agent0"
+        name = "alice:agent0"
+        assert name == primary  # This would trigger the guard
 
     def test_duplicate_agent_detection(self):
         """Verify duplicate agent names are detected."""
-        agents = {"agent0": {"status": "running"}}
-        name = "agent0"
+        agents = {"alice:agent0": {"status": "running"}}
+        name = "alice:agent0"
         assert name in agents
 
     def test_agent_status_tracking(self):
         """Test agent status update from presence signals."""
-        agents = {"agent0": {"status": "running", "workspace": "/tmp"}}
+        agents = {"alice:agent0": {"status": "running", "workspace": "/tmp"}}
 
         # Simulate presence signal
-        ev = {"nick": "agent0", "online": False}
+        ev = {"nick": "alice:agent0", "online": False}
         nick = ev["nick"]
         if nick in agents:
             agents[nick]["status"] = "running" if ev["online"] else "offline"
 
-        assert agents["agent0"]["status"] == "offline"
+        assert agents["alice:agent0"]["status"] == "offline"
 
     def test_structured_command_parsing(self):
         """Test parsing of agent's structured command output."""

--- a/tests/unit/test_message.py
+++ b/tests/unit/test_message.py
@@ -49,30 +49,34 @@ class TestMessageDedup:
 
 class TestMentionDetection:
     def test_mention_present(self):
-        assert detect_mention("hey @agent0 do stuff", "agent0") is True
+        assert detect_mention("hey @alice:agent0 do stuff", "alice:agent0") is True
 
     def test_mention_absent(self):
-        assert detect_mention("hello everyone", "agent0") is False
+        assert detect_mention("hello everyone", "alice:agent0") is False
 
     def test_mention_different_agent(self):
-        assert detect_mention("@agent1 help", "agent0") is False
+        assert detect_mention("@bob:agent1 help", "alice:agent0") is False
 
     def test_mention_at_start(self):
-        assert detect_mention("@agent0 list files", "agent0") is True
+        assert detect_mention("@alice:agent0 list files", "alice:agent0") is True
 
     def test_mention_at_end(self):
-        assert detect_mention("help me @agent0", "agent0") is True
+        assert detect_mention("help me @alice:agent0", "alice:agent0") is True
+
+    def test_mention_no_collision_across_users(self):
+        """alice:agent0 and bob:agent0 should not collide."""
+        assert detect_mention("@bob:agent0 help", "alice:agent0") is False
 
 
 class TestCleanMention:
     def test_removes_mention(self):
-        assert clean_mention("@agent0 list files", "agent0") == "list files"
+        assert clean_mention("@alice:agent0 list files", "alice:agent0") == "list files"
 
     def test_removes_mention_middle(self):
-        assert clean_mention("hey @agent0 do stuff", "agent0") == "hey  do stuff"
+        assert clean_mention("hey @alice:agent0 do stuff", "alice:agent0") == "hey  do stuff"
 
     def test_no_mention_unchanged(self):
-        assert clean_mention("hello world", "agent0") == "hello world"
+        assert clean_mention("hello world", "alice:agent0") == "hello world"
 
 
 class TestMakeDmPair:
@@ -86,7 +90,7 @@ class TestMakeDmPair:
         assert make_dm_pair("alice", "alice") == "alice_alice"
 
     def test_agent_pair(self):
-        assert make_dm_pair("agent0", "alice") == "agent0_alice"
+        assert make_dm_pair("alice:agent0", "bob") == "alice:agent0_bob"
 
 
 class TestTopicHelpers:
@@ -97,7 +101,7 @@ class TestTopicHelpers:
         assert room_topic("general") == "wc/rooms/general/messages"
 
     def test_presence_topic(self):
-        assert presence_topic("agent0") == "wc/presence/agent0"
+        assert presence_topic("alice:agent0") == "wc/presence/alice:agent0"
 
 
 class TestChunkMessage:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -5,8 +5,8 @@ import os
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
-# Patch AGENT_NAME before importing tools
-os.environ["AGENT_NAME"] = "agent0"
+# Patch AGENT_NAME before importing tools (scoped to creator per issue #2)
+os.environ["AGENT_NAME"] = "alice:agent0"
 
 from tools import register_tools
 
@@ -33,9 +33,9 @@ class TestReplyTool:
         assert "Sent" in result
         assert len(session.published) == 1
         key, payload = session.published[0]
-        assert key == "wc/dm/agent0_alice/messages"
+        assert key == "wc/dm/alice_alice:agent0/messages"
         msg = json.loads(payload)
-        assert msg["nick"] == "agent0"
+        assert msg["nick"] == "alice:agent0"
         assert msg["body"] == "hello"
         assert msg["type"] == "msg"
 

--- a/tests/unit/test_zenoh_protocol.py
+++ b/tests/unit/test_zenoh_protocol.py
@@ -48,7 +48,7 @@ class TestDmPairSorting:
         assert make_dm_pair("bob", "alice") == "alice_bob"
 
     def test_pair_with_agent(self):
-        assert make_dm_pair("agent0", "zara") == "agent0_zara"
+        assert make_dm_pair("alice:agent0", "zara") == "alice:agent0_zara"
 
     def test_pair_symmetric(self):
         assert make_dm_pair("x", "y") == make_dm_pair("y", "x")
@@ -62,7 +62,7 @@ class TestTopicFormats:
         assert dm_topic("alice_bob") == "wc/dm/alice_bob/messages"
 
     def test_presence_topic(self):
-        assert presence_topic("agent0") == "wc/presence/agent0"
+        assert presence_topic("alice:agent0") == "wc/presence/alice:agent0"
 
     def test_room_presence_format(self):
         # Room presence follows: wc/rooms/{room}/presence/{nick}

--- a/weechat-agent/weechat-agent.py
+++ b/weechat-agent/weechat-agent.py
@@ -21,7 +21,16 @@ SCRIPT_DESC = "Claude Code agent lifecycle management for WeeChat"
 agents = {}                # name → { workspace, tmux_pane, status }
 CHANNEL_PLUGIN_DIR = ""    # weechat-channel-server plugin 路径
 TMUX_SESSION = ""          # tmux session 名称
+USERNAME = ""              # 当前用户名（用于 agent 名称作用域）
+PRIMARY_AGENT = ""         # 主 agent 全名（如 alice:agent0）
 next_pane_id = 1
+
+
+def scoped_name(name):
+    """给 agent 名称加上用户名前缀（如已有前缀则不重复添加）。"""
+    if ":" in name:
+        return name
+    return f"{USERNAME}:{name}"
 
 
 # ============================================================
@@ -29,19 +38,24 @@ next_pane_id = 1
 # ============================================================
 
 def agent_init():
-    global CHANNEL_PLUGIN_DIR, TMUX_SESSION
+    global CHANNEL_PLUGIN_DIR, TMUX_SESSION, USERNAME, PRIMARY_AGENT
 
     CHANNEL_PLUGIN_DIR = weechat.config_get_plugin("channel_plugin_dir")
     TMUX_SESSION = weechat.config_get_plugin("tmux_session") or "weechat-claude"
+    USERNAME = weechat.config_string(
+        weechat.config_get("plugins.var.python.weechat-zenoh.nick")
+    ) or os.environ.get("USER", "user")
+
+    PRIMARY_AGENT = scoped_name("agent0")
 
     # 注册 agent0（由 start.sh 预启动）
     if weechat.config_get_plugin("agent0_workspace"):
-        agents["agent0"] = {
+        agents[PRIMARY_AGENT] = {
             "workspace": weechat.config_get_plugin("agent0_workspace"),
             "status": "running",
         }
         # 为 agent0 创建 DM buffer
-        weechat.command("", "/zenoh join @agent0")
+        weechat.command("", f"/zenoh join @{PRIMARY_AGENT}")
 
     # 监听消息 signal，检测 Agent 的结构化命令输出
     weechat.hook_signal("zenoh_message_received",
@@ -57,6 +71,7 @@ def agent_init():
 # ============================================================
 
 def create_agent(name, workspace):
+    name = scoped_name(name)
     if name in agents:
         weechat.prnt("", f"[agent] {name} already exists")
         return
@@ -100,8 +115,9 @@ def create_agent(name, workspace):
 # ============================================================
 
 def stop_agent(name):
-    if name == "agent0":
-        weechat.prnt("", "[agent] Cannot stop agent0")
+    name = scoped_name(name)
+    if name == PRIMARY_AGENT:
+        weechat.prnt("", f"[agent] Cannot stop {PRIMARY_AGENT}")
         return
     if name not in agents:
         weechat.prnt("", f"[agent] Unknown agent: {name}")
@@ -177,7 +193,7 @@ def agent_cmd_cb(data, buffer, args):
         stop_agent(argv[1])
 
     elif cmd == "restart" and len(argv) >= 2:
-        name = argv[1]
+        name = scoped_name(argv[1])
         if name in agents:
             ws = agents[name]["workspace"]
             stop_agent(name)
@@ -194,7 +210,7 @@ def agent_cmd_cb(data, buffer, args):
                     f"  {name}\t{info['status']}\t{info['workspace']}")
 
     elif cmd == "join" and len(argv) >= 3:
-        agent_name = argv[1]
+        agent_name = scoped_name(argv[1])
         room = argv[2]
         if agent_name not in agents:
             weechat.prnt(buffer, f"[agent] Unknown agent: {agent_name}")
@@ -225,7 +241,7 @@ def restart_timer_cb(data, remaining_calls):
 
 def agent_deinit():
     for name in list(agents.keys()):
-        if name != "agent0":
+        if name != PRIMARY_AGENT:
             stop_agent(name)
     return weechat.WEECHAT_RC_OK
 
@@ -248,8 +264,8 @@ if weechat.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION,
         "Manage Claude Code agents",
         "create <n> [--workspace <path>] || stop <n> || "
         "restart <n> || list || join <agent> <#room>",
-        "  create: Launch new Claude Code instance\n"
-        "    stop: Stop an agent (cannot stop agent0)\n"
+        "  create: Launch new Claude Code instance (name auto-scoped to user)\n"
+        "    stop: Stop an agent (cannot stop primary agent)\n"
         " restart: Restart an agent\n"
         "    list: List all agents and status\n"
         "    join: Ask agent to join a room",


### PR DESCRIPTION
## Summary
- Agent names are now scoped to their creator using `:` separator (e.g. `alice:agent0`)
- `weechat-agent.py` auto-prefixes username via `scoped_name()` for all agent commands (create/stop/restart/join)
- `start.sh` passes `$USERNAME:agent0` as `AGENT_NAME` env var

## Test plan
- [x] All 46 unit tests pass with scoped names
- [ ] Manual: run `start.sh` and verify agent registers as `{username}:agent0`
- [ ] Manual: `/agent create helper` creates `{username}:helper`
- [ ] Manual: two users on same zenohd don't collide

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)