### PR TITLE
fix: replace deprecated plugin: loading with --mcp-config

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -54,12 +54,26 @@ ln -sf "../weechat-agent.py" "$WC_DIR/python/autoload/"
 tmux kill-session -t "$SESSION" 2>/dev/null || true
 tmux new-session -d -s "$SESSION" -x 220 -y 50
 
-# --- Pane 0: Claude Code (agent0) with channel plugin ---
+# --- 生成 agent0 MCP config ---
+MCP_CONFIG="/tmp/wc-mcp-${USERNAME}-agent0.json"
+cat > "$MCP_CONFIG" << MCPEOF
+{
+  "mcpServers": {
+    "weechat-channel": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "--project", "$SCRIPT_DIR/weechat-channel-server", "python3", "$SCRIPT_DIR/weechat-channel-server/server.py"],
+      "env": { "AGENT_NAME": "$USERNAME:agent0" }
+    }
+  }
+}
+MCPEOF
+
+# --- Pane 0: Claude Code (agent0) with MCP channel server ---
 tmux send-keys -t "$SESSION" \
-  "cd '$WORKSPACE' && AGENT_NAME='$USERNAME:agent0' claude \
-    --dangerously-skip-permissions \
-    --dangerously-load-development-channels \
-    plugin:weechat-channel" Enter
+  "cd '$WORKSPACE' && claude \
+    --permission-mode bypassPermissions \
+    --mcp-config '$MCP_CONFIG'" Enter
 
 echo -n "  Waiting for $USERNAME:agent0..."
 sleep 5

--- a/weechat-agent/weechat-agent.py
+++ b/weechat-agent/weechat-agent.py
@@ -10,6 +10,7 @@ import weechat
 import json
 import os
 import subprocess
+import tempfile
 
 SCRIPT_NAME = "weechat-agent"
 SCRIPT_AUTHOR = "Allen <ezagent42>"
@@ -67,6 +68,46 @@ def agent_init():
 
 
 # ============================================================
+# MCP Config 生成
+# ============================================================
+
+def _mcp_config_path(name):
+    """返回 agent 对应的临时 MCP config 路径。"""
+    safe = name.replace(":", "-")
+    return os.path.join(tempfile.gettempdir(), f"wc-mcp-{safe}.json")
+
+
+def _generate_mcp_config(name):
+    """生成 MCP config JSON，返回文件路径。"""
+    config = {
+        "mcpServers": {
+            "weechat-channel": {
+                "type": "stdio",
+                "command": "uv",
+                "args": [
+                    "run", "--project", CHANNEL_PLUGIN_DIR,
+                    "python3", os.path.join(CHANNEL_PLUGIN_DIR, "server.py"),
+                ],
+                "env": {"AGENT_NAME": name},
+            }
+        }
+    }
+    path = _mcp_config_path(name)
+    with open(path, "w") as f:
+        json.dump(config, f)
+    return path
+
+
+def _cleanup_mcp_config(name):
+    """删除 agent 的临时 MCP config。"""
+    path = _mcp_config_path(name)
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+# ============================================================
 # Agent 创建
 # ============================================================
 
@@ -84,14 +125,13 @@ def create_agent(name, workspace):
 
     workspace = os.path.abspath(workspace)
 
-    # 1. 在 tmux pane 中启动 Claude Code with channel plugin
+    # 1. 生成 MCP config 并在 tmux pane 中启动 Claude Code
+    mcp_config = _generate_mcp_config(name)
     cmd = (
         f"cd '{workspace}' && "
-        f"AGENT_NAME='{name}' "
         f"claude "
-        f"--dangerously-skip-permissions "
-        f"--dangerously-load-development-channels "
-        f"plugin:weechat-channel"
+        f"--permission-mode bypassPermissions "
+        f"--mcp-config '{mcp_config}'"
     )
     result = subprocess.run(
         ["tmux", "split-window", "-h", "-P", "-F", "#{pane_id}",
@@ -105,6 +145,7 @@ def create_agent(name, workspace):
         "workspace": workspace,
         "status": "starting",
         "pane_id": pane_id,
+        "mcp_config": mcp_config,
     }
 
     # 3. 通知 weechat-zenoh 创建 private buffer
@@ -134,6 +175,7 @@ def stop_agent(name):
             capture_output=True
         )
 
+    _cleanup_mcp_config(name)
     agents[name]["status"] = "stopped"
     weechat.prnt("", f"[agent] Stopped {name}")
 
@@ -249,6 +291,7 @@ def agent_deinit():
     for name in list(agents.keys()):
         if name != PRIMARY_AGENT:
             stop_agent(name)
+        _cleanup_mcp_config(name)
     return weechat.WEECHAT_RC_OK
 
 


### PR DESCRIPTION
## Summary

- `create_agent()` and `start.sh` used `--dangerously-load-development-channels plugin:weechat-channel`, which claude CLI no longer accepts
- Replaced with `--mcp-config` using per-agent temp JSON configs (matching E2E-tested pattern from `helpers.sh:create_mcp_config()`)
- `AGENT_NAME` now injected via config `env` field instead of shell environment variable

## Changed files

- **`weechat-agent/weechat-agent.py`** — add `_generate_mcp_config()` / `_cleanup_mcp_config()`, update `create_agent()`, `stop_agent()`, `agent_deinit()`
- **`start.sh`** — generate MCP config JSON before launching agent0

## Test plan

- [ ] Run `./start.sh ~/workspace alice` — verify agent0 starts and connects to Zenoh
- [ ] In WeeChat, run `/agent create agent1 --workspace ~/workspace` — verify agent1 stays running
- [ ] `/agent list` shows both agents as `running`
- [ ] `/agent stop agent1` cleans up temp config at `/tmp/wc-mcp-*.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)