### PR TITLE
feat: agent-to-agent spawning and communication

### DIFF
--- a/tests/e2e/e2e-test-manual.sh
+++ b/tests/e2e/e2e-test-manual.sh
@@ -215,6 +215,101 @@ else
 fi
 
 # ============================================================
+# Phase 7: agent0 creates agent2 (agent-to-agent spawning)
+# ============================================================
+step "Phase 7: agent0 creates agent2 via create_agent tool"
+
+# Capture pane IDs before creation
+PANES_BEFORE=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id}' | sort)
+
+tmux send-keys -t "$PANE_AGENT0" \
+    'Use the create_agent MCP tool to create a new agent named "agent2"' Enter
+
+if wait_for_pane "$PANE_AGENT0" "agent2" 45; then
+    pass "agent0: create_agent tool called"
+else
+    fail "agent0: create_agent tool not called within timeout"
+fi
+
+sleep 10
+tmux send-keys -t "$PANE_ALICE" "/agent list" Enter
+sleep 2
+
+if pane_contains "$PANE_ALICE" "agent2"; then
+    pass "alice: agent2 created and listed in /agent list"
+else
+    sleep 10
+    tmux send-keys -t "$PANE_ALICE" "/agent list" Enter
+    sleep 2
+    if pane_contains "$PANE_ALICE" "agent2"; then
+        pass "alice: agent2 created and listed in /agent list (retry)"
+    else
+        fail "alice: agent2 not found in /agent list"
+    fi
+fi
+
+info "Waiting for agent2 to initialize..."
+sleep 20
+
+pause
+
+# ============================================================
+# Phase 8: agent0 ↔ agent2 communication (agent-to-agent)
+# ============================================================
+step "Phase 8: agent0 ↔ agent2 private messaging"
+
+tmux send-keys -t "$PANE_AGENT0" \
+    'Use the reply MCP tool to send a private message to "alice:agent2" with text: "Hello agent2, please reply with the word PONG to confirm you received this."' Enter
+
+if wait_for_pane "$PANE_AGENT0" "Sent to" 30; then
+    pass "agent0: sent private message to agent2"
+else
+    fail "agent0: failed to send private message to agent2"
+fi
+
+# Find agent2's pane by comparing with panes before creation
+PANES_AFTER=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id}' | sort)
+AGENT2_PANE=$(comm -13 <(echo "$PANES_BEFORE") <(echo "$PANES_AFTER") | head -1)
+
+if [ -n "$AGENT2_PANE" ]; then
+    if wait_for_pane "$AGENT2_PANE" "PONG" 60; then
+        pass "agent2: received message and replied with PONG"
+    elif wait_for_pane "$AGENT2_PANE" "Sent to" 30; then
+        pass "agent2: processed message and sent reply"
+    else
+        fail "agent2: did not respond to agent0's message"
+    fi
+else
+    fail "agent2: pane not found"
+fi
+
+if wait_for_pane "$PANE_AGENT0" "PONG" 30; then
+    pass "agent0: received agent2's PONG reply"
+else
+    info "agent0: PONG not visible in pane (may have scrolled)"
+fi
+
+pause
+
+# ============================================================
+# Phase 9: stop agent2
+# ============================================================
+step "Phase 9: stop agent2"
+
+if [ -n "$AGENT2_PANE" ]; then
+    tmux send-keys -t "$AGENT2_PANE" "/exit" Enter
+    if wait_for_pane "$PANE_ALICE" "agent2.*offline" 30; then
+        pass "agent2: exited and offline notification received"
+    else
+        info "agent2: /exit sent but offline notification not detected"
+    fi
+else
+    info "agent2: pane already gone"
+fi
+
+pause
+
+# ============================================================
 # Summary + cleanup
 # ============================================================
 step "Summary"

--- a/tests/e2e/e2e-test.sh
+++ b/tests/e2e/e2e-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# e2e-test.sh — Full E2E test: alice + bob + alice:agent0 + alice:agent1
+# e2e-test.sh — Full E2E test: alice + bob + agent0 + agent1 + agent2
 #
 # Layout:
 #   ┌──────────────────┬──────────────────┐
@@ -8,6 +8,9 @@
 #   ├──────────────────┼──────────────────┤
 #   │ bob (WeeChat)    │ alice:agent1     │
 #   │                  │ (/agent create)  │
+#   │                  ├──────────────────┤
+#   │                  │ alice:agent2     │
+#   │                  │ (agent0 creates) │
 #   └──────────────────┴──────────────────┘
 set -euo pipefail
 
@@ -207,7 +210,105 @@ else
 fi
 
 # ============================================================
-# Phase 7: Summary
+# Phase 7: agent0 creates agent2 (agent-to-agent spawning)
+# ============================================================
+step "Phase 7: agent0 creates agent2 via create_agent tool"
+
+# Capture pane IDs before creation so we can find agent2's new pane
+PANES_BEFORE=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id}' | sort)
+
+# agent0 uses the create_agent MCP tool to spawn agent2
+tmux send-keys -t "$PANE_AGENT0" \
+    'Use the create_agent MCP tool to create a new agent named "agent2"' Enter
+
+# Wait for agent0 to call the tool (needs time to process instruction)
+if wait_for_pane "$PANE_AGENT0" "agent2" 45; then
+    pass "agent0: create_agent tool called"
+else
+    fail "agent0: create_agent tool not called within timeout"
+fi
+
+# Wait for weechat-agent to detect and spawn agent2, then verify via /agent list
+sleep 10
+tmux send-keys -t "$PANE_ALICE" "/agent list" Enter
+sleep 2
+
+if pane_contains "$PANE_ALICE" "agent2"; then
+    pass "alice: agent2 created and listed in /agent list"
+else
+    # Retry — creation might still be in progress
+    sleep 10
+    tmux send-keys -t "$PANE_ALICE" "/agent list" Enter
+    sleep 2
+    if pane_contains "$PANE_ALICE" "agent2"; then
+        pass "alice: agent2 created and listed in /agent list (retry)"
+    else
+        fail "alice: agent2 not found in /agent list"
+    fi
+fi
+
+# Wait for agent2 to fully initialize (MCP server + Zenoh)
+info "Waiting for agent2 to initialize..."
+sleep 20
+
+# ============================================================
+# Phase 8: agent0 ↔ agent2 communication (agent-to-agent)
+# ============================================================
+step "Phase 8: agent0 ↔ agent2 private messaging"
+
+# agent0 sends a task to agent2 via private message
+tmux send-keys -t "$PANE_AGENT0" \
+    'Use the reply MCP tool to send a private message to "alice:agent2" with text: "Hello agent2, please reply with the word PONG to confirm you received this."' Enter
+
+# Wait for agent0 to confirm the message was sent
+if wait_for_pane "$PANE_AGENT0" "Sent to" 30; then
+    pass "agent0: sent private message to agent2"
+else
+    fail "agent0: failed to send private message to agent2"
+fi
+
+# Find agent2's pane by comparing with panes before creation
+PANES_AFTER=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id}' | sort)
+AGENT2_PANE=$(comm -13 <(echo "$PANES_BEFORE") <(echo "$PANES_AFTER") | head -1)
+
+# Wait for agent2 to receive and process the message (it should auto-respond)
+if [ -n "$AGENT2_PANE" ]; then
+    if wait_for_pane "$AGENT2_PANE" "PONG" 60; then
+        pass "agent2: received message and replied with PONG"
+    elif wait_for_pane "$AGENT2_PANE" "Sent to" 30; then
+        pass "agent2: processed message and sent reply"
+    else
+        fail "agent2: did not respond to agent0's message"
+    fi
+else
+    fail "agent2: pane not found"
+fi
+
+# Verify agent0 received agent2's reply (via channel notification)
+if wait_for_pane "$PANE_AGENT0" "PONG" 30; then
+    pass "agent0: received agent2's PONG reply"
+else
+    info "agent0: PONG not visible in pane (may have scrolled)"
+fi
+
+# ============================================================
+# Phase 9: stop agent2
+# ============================================================
+step "Phase 9: stop agent2"
+
+if [ -n "$AGENT2_PANE" ]; then
+    tmux send-keys -t "$AGENT2_PANE" "/exit" Enter
+    if wait_for_pane "$PANE_ALICE" "agent2.*offline" 30; then
+        pass "agent2: exited and offline notification received"
+    else
+        info "agent2: /exit sent but offline notification not detected"
+    fi
+else
+    info "agent2: pane already gone"
+fi
+
+# ============================================================
+# Phase 10: Summary
 # ============================================================
 step "Summary"
 

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -9,7 +9,7 @@ os.environ["AGENT_NAME"] = "alice:agent0"
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "weechat-channel-server"))
-from server import _handle_reply
+from server import _handle_reply, _handle_create_agent
 
 class TestReplyTool:
     @pytest.fixture
@@ -42,3 +42,28 @@ class TestReplyTool:
         for field in ("id", "nick", "type", "body", "ts"):
             assert field in msg
         assert isinstance(msg["ts"], float)
+
+
+class TestCreateAgentTool:
+    @pytest.fixture
+    def mock_zenoh(self):
+        session = MagicMock()
+        session.put = MagicMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_create_agent_sends_to_general(self, mock_zenoh):
+        result = await _handle_create_agent(mock_zenoh, {"name": "agent2"})
+        assert "agent2" in result[0].text
+        mock_zenoh.put.assert_called_once()
+        key = mock_zenoh.put.call_args[0][0]
+        assert key == "wc/channels/general/messages"
+
+    @pytest.mark.asyncio
+    async def test_create_agent_message_format(self, mock_zenoh):
+        await _handle_create_agent(mock_zenoh, {"name": "helper"})
+        outer = json.loads(mock_zenoh.put.call_args[0][1])
+        assert outer["nick"] == "alice:agent0"
+        inner = json.loads(outer["body"])
+        assert inner["action"] == "create_agent"
+        assert inner["name"] == "helper"

--- a/weechat-agent/weechat-agent.py
+++ b/weechat-agent/weechat-agent.py
@@ -126,11 +126,12 @@ def _find_claude_pane():
 
 
 def _last_agent_pane():
-    """Return the pane_id of the last registered agent (for split targeting)."""
+    """Return the pane_id of the last running agent (for split targeting)."""
     for name in reversed(list(agents.keys())):
-        pane = agents[name].get("pane_id")
-        if pane:
-            return pane
+        if agents[name].get("status") not in ("offline", None):
+            pane = agents[name].get("pane_id")
+            if pane:
+                return pane
     return ""
 
 

--- a/weechat-channel-server/server.py
+++ b/weechat-channel-server/server.py
@@ -189,6 +189,17 @@ def register_tools(server: Server, state: dict):
                     "required": ["channel_name"],
                 },
             ),
+            Tool(
+                name="create_agent",
+                description="Create a new Claude Code agent. Sends a structured command to the WeeChat agent manager which spawns a new agent in a tmux pane with its own MCP server.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Agent name (e.g. 'agent2'). Will be auto-prefixed with username."},
+                    },
+                    "required": ["name"],
+                },
+            ),
         ]
 
     @server.call_tool()
@@ -198,6 +209,8 @@ def register_tools(server: Server, state: dict):
             return await _handle_reply(zenoh_session, arguments)
         elif name == "join_channel":
             return await _handle_join_channel(zenoh_session, arguments)
+        elif name == "create_agent":
+            return await _handle_create_agent(zenoh_session, arguments)
         raise ValueError(f"Unknown tool: {name}")
 
 async def _handle_reply(zenoh_session, arguments: dict) -> list[TextContent]:
@@ -224,6 +237,24 @@ async def _handle_join_channel(zenoh_session, arguments: dict) -> list[TextConte
     channel = arguments["channel_name"]
     zenoh_session.liveliness().declare_token(channel_presence_topic(channel, AGENT_NAME))
     return [TextContent(type="text", text=f"Joined #{channel}")]
+
+
+async def _handle_create_agent(zenoh_session, arguments: dict) -> list[TextContent]:
+    """Create a new agent by sending a structured command to #general.
+
+    The weechat-agent plugin monitors channel messages from registered agents
+    and detects JSON commands with action="create_agent".
+    """
+    name = arguments["name"]
+    cmd = json.dumps({
+        "id": os.urandom(8).hex(),
+        "nick": AGENT_NAME,
+        "type": "msg",
+        "body": json.dumps({"action": "create_agent", "name": name}),
+        "ts": time.time(),
+    })
+    zenoh_session.put(channel_topic("general"), cmd)
+    return [TextContent(type="text", text=f"Requested creation of agent '{name}' via #general")]
 
 # ============================================================
 # Main


### PR DESCRIPTION
## Summary

- **New `create_agent` MCP tool** — agents can now explicitly create sub-agents via a proper MCP tool instead of crafting raw JSON
- **Fix `_last_agent_pane()` bug** — was targeting dead agent panes for tmux splits, causing new agents to spawn outside the session
- **E2E test: agent0 ↔ agent2 round-trip** — Phase 7 (agent0 creates agent2), Phase 8 (agent0 sends PONG task via private message, agent2 responds), Phase 9 (cleanup)

## Test plan

- [x] Unit tests pass (`TestCreateAgentTool` — message format and routing)
- [x] Full E2E test passes including new phases 7-9
- [ ] Manual E2E test with pause points (`e2e-test-manual.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)