### PR TITLE
fix(project): graceful handling when tmux session not yet created

### DIFF
--- a/zchat/cli/app.py
+++ b/zchat/cli/app.py
@@ -210,13 +210,20 @@ def cmd_project_use(name: str):
     cfg = load_project_config(name)
     session_name = cfg.get("tmux", {}).get("session", f"zchat-{name}")
     typer.echo(f"Default project set to '{name}'.")
-    # Attach to the project's tmux session
+    # Attach to the project's tmux session if it exists
     import subprocess
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        typer.echo(
+            f"Session not running. Use 'zchat irc start' to start it."
+        )
+        return
     if os.environ.get("TMUX"):
-        # Already inside tmux — switch client
         subprocess.run(["tmux", "switch-client", "-t", session_name])
     else:
-        # Outside tmux — attach
         subprocess.run(["tmux", "attach", "-t", session_name])
 
 @project_app.command("remove")


### PR DESCRIPTION
## Summary
- `project use` now checks if the tmux session exists before attempting to attach
- Shows a helpful hint ("Session not running. Use 'zchat irc start' to start it.") instead of leaking the raw tmux "can't find session" error

## Test plan
- [x] Unit tests pass (44/44)
- [ ] `zchat project use <name>` when session not running → friendly message
- [ ] `zchat project use <name>` when session running → attaches normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)