### PR TITLE
feat(agent): configurable mcp_server_cmd and dev-loop-skills

### DIFF
--- a/docs/dev-loop-guide.md
+++ b/docs/dev-loop-guide.md
@@ -2,6 +2,16 @@
 
 > 功能开发流水线。所有 feature / bug 修复统一走这个流程。
 
+## 快速开始
+
+在飞书群或 IRC 中，向 Agent 发送 `/dev-loop` + 需求描述即可启动流水线：
+
+```
+/dev-loop 我想给 zchat 加一个 dm send 命令
+```
+
+Agent 会自动走完下面的完整流程。
+
 ## 流程总览
 
 ```
@@ -123,7 +133,7 @@ Agent 跑完测试后在 issue comment 贴报告摘要。你决定下一步：
 
 ### Phase 1：提需求
 
-**你说**："我想给 zchat 加一个 dm send 命令"
+**你说**：`/dev-loop 我想给 zchat 加一个 dm send 命令`
 
 **Agent 做**：创建 `feat/dm-support` 分支 → 分析代码 → 生成评估文档 → 创建 GitHub issue #54
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -89,6 +89,16 @@ zchat project use local
 
 agent0 会通过 IRC 收到你的消息，然后回复到 channel 中。
 
+### 使用 dev-loop 开发流水线
+
+如果项目启用了 dev-loop-skills 插件，可以通过 `/dev-loop` 命令触发完整的功能开发流水线：
+
+```
+@agent0 /dev-loop 我想给 zchat 加一个 dm send 命令
+```
+
+agent 会自动走完需求评估 → 编码 → 测试计划 → 写测试 → 跑测试 → 归档的完整流程。
+
 ## 停止
 
 ```bash

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -61,6 +61,20 @@
 | `/agent list` | 列出 agent 状态 |
 | `/agent restart <name>` | 重启 agent |
 
+### Agent 聊天命令
+
+在频道中 @agent 时，可使用以下命令：
+
+| 命令 | 说明 |
+|------|------|
+| `/dev-loop <描述>` | 触发 dev-loop 开发流水线（需求评估 → 编码 → 测试 → 归档） |
+
+示例：
+
+```
+@agent0 /dev-loop 我想给 zchat 加一个 dm send 命令
+```
+
 ## 使用场景
 
 ### 场景 1：人 ↔ Agent 对话

--- a/zchat/cli/agent_manager.py
+++ b/zchat/cli/agent_manager.py
@@ -40,7 +40,8 @@ class AgentManager:
                  default_type: str = "claude",
                  zellij_session: str = "zchat",
                  state_file: str = DEFAULT_STATE_FILE,
-                 project_dir: str = ""):
+                 project_dir: str = "",
+                 mcp_server_cmd: str = "zchat-channel"):
         self.irc_server = irc_server
         self.irc_port = irc_port
         self.irc_tls = irc_tls
@@ -52,6 +53,7 @@ class AgentManager:
         self._session_name = zellij_session
         self._state_file = state_file
         self.project_dir = project_dir
+        self.mcp_server_cmd = mcp_server_cmd
         self._agents: dict[str, dict] = {}
         self._load_state()
 
@@ -181,6 +183,7 @@ class AgentManager:
             context["channel_pkg_dir"] = channel_pkg
         else:
             context["channel_pkg_dir"] = ""
+        context["mcp_server_cmd"] = self.mcp_server_cmd
         return context
 
     def _spawn_tab(self, name: str, workspace: str, agent_type: str,

--- a/zchat/cli/app.py
+++ b/zchat/cli/app.py
@@ -153,6 +153,8 @@ def _get_agent_manager(ctx: typer.Context) -> AgentManager:
     cfg = _get_config(ctx)
     project_name = ctx.obj["project"]
     irc = _get_irc_config(cfg)
+    mcp_cmd_list = cfg.get("mcp_server_cmd", ["zchat-channel"])
+    mcp_server_cmd = " ".join(mcp_cmd_list) if isinstance(mcp_cmd_list, list) else mcp_cmd_list
     return AgentManager(
         irc_server=irc["host"],
         irc_port=irc["port"],
@@ -165,6 +167,7 @@ def _get_agent_manager(ctx: typer.Context) -> AgentManager:
         zellij_session=_get_zellij_session(ctx),
         state_file=state_file_path(project_name),
         project_dir=project_dir(project_name),
+        mcp_server_cmd=mcp_server_cmd,
     )
 
 

--- a/zchat/cli/templates/claude/.env.example
+++ b/zchat/cli/templates/claude/.env.example
@@ -15,7 +15,7 @@ ZCHAT_PROJECT_DIR={{zchat_project_dir}}
 ANTHROPIC_API_KEY=
 
 # MCP server command — override for dev (e.g., "uv run --project /path zchat-channel")
-MCP_SERVER_CMD=zchat-channel
+MCP_SERVER_CMD={{mcp_server_cmd}}
 
 # Channel server package directory (resolved by zchat agent create)
 CHANNEL_PKG_DIR={{channel_pkg_dir}}

--- a/zchat/cli/templates/claude/soul.md
+++ b/zchat/cli/templates/claude/soul.md
@@ -18,3 +18,7 @@ The default message handling strategy (in your MCP instructions) uses quick resp
 - **Code review requests** — If someone asks you to review code or a PR, acknowledge receipt and add it to your task queue. Do not attempt a full review in a quick reply.
 - **Bug reports from owner** — Treat as high priority. If idle, investigate immediately. If busy, finish current task first but prioritize it next.
 - **Casual conversation** — Keep it brief and friendly. Do not over-explain or be overly formal.
+
+## Slash Commands
+
+When a message starts with `/dev-loop`, invoke the `using-dev-loop` skill via the Skill tool before responding. Pass the text after `/dev-loop` as the skill argument. The skill router will automatically dispatch to the correct phase (eval, test-plan, test-write, test-run, etc.).

--- a/zchat/cli/templates/claude/soul.md
+++ b/zchat/cli/templates/claude/soul.md
@@ -21,4 +21,12 @@ The default message handling strategy (in your MCP instructions) uses quick resp
 
 ## Slash Commands
 
-When a message starts with `/dev-loop`, invoke the `using-dev-loop` skill via the Skill tool before responding. Pass the text after `/dev-loop` as the skill argument. The skill router will automatically dispatch to the correct phase (eval, test-plan, test-write, test-run, etc.).
+When a message contains `/dev-loop`, you MUST invoke the `dev-loop-skills:using-dev-loop` skill using the Skill tool:
+
+```
+Skill(skill: "dev-loop-skills:using-dev-loop", args: "<the text after /dev-loop>")
+```
+
+This is a BLOCKING REQUIREMENT — always call the Skill tool first, before generating any other response. The `dev-loop-skills@ezagent42` plugin provides a complete development pipeline (eval → code → test-plan → test-write → test-run → archive). The `using-dev-loop` skill is the router that dispatches to the correct phase automatically.
+
+Do NOT attempt to handle `/dev-loop` requests yourself — always delegate to the skill.

--- a/zchat/cli/templates/claude/start.sh
+++ b/zchat/cli/templates/claude/start.sh
@@ -52,7 +52,8 @@ jq -n \
       ]
     },
     enabledPlugins: {
-      "zchat@ezagent42": true
+      "zchat@ezagent42": true,
+      "dev-loop-skills@ezagent42": true
     }
   }' > .claude/settings.local.json
 
@@ -103,5 +104,5 @@ fi
 # Write .mcp.json
 jq -n --argjson srv "$SERVER_JSON" '{"mcpServers": {"zchat-channel": $srv}}' > .mcp.json
 
-exec claude --permission-mode bypassPermissions \
+exec -a "zchat-claude-agent" claude --permission-mode bypassPermissions \
   --dangerously-load-development-channels server:zchat-channel


### PR DESCRIPTION
## Summary
- Add `mcp_server_cmd` parameter to AgentManager, sourced from project `config.toml`
- Replace hardcoded `MCP_SERVER_CMD=zchat-channel` in `.env.example` with `{{mcp_server_cmd}}` placeholder
- Enable `dev-loop-skills@ezagent42` plugin in agent `settings.local.json` template
- Use `exec -a "zchat-claude-agent"` for identifiable process name in `ps` output

This enables running zchat from source code instead of the homebrew-installed version, by setting `mcp_server_cmd` in `config.toml`:
```toml
mcp_server_cmd = ["uv", "run", "--project", "/path/to/zchat-channel-server", "zchat-channel"]
```

## Test plan
- [ ] `zchat agent create` uses configured `mcp_server_cmd` from config.toml
- [ ] Agent loads `dev-loop-skills` plugin on startup
- [ ] Default behavior (no `mcp_server_cmd` in config) falls back to `zchat-channel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)