### PR TITLE
fix(audit): V7 path · audit_cmd 读 plugins/audit/state.json

### DIFF
--- a/tests/unit/test_audit_cli.py
+++ b/tests/unit/test_audit_cli.py
@@ -16,7 +16,10 @@ runner = CliRunner()
 
 @pytest.fixture
 def audit_json(tmp_path, monkeypatch):
-    """构造一个 audit.json 并通过 CS_DATA_DIR 环境变量让 CLI 找到。"""
+    """构造一个 audit plugin state.json 并 monkeypatch project_dir 让 CLI 找到。
+
+    V7 路径：<project_dir>/plugins/audit/state.json（V6 的 audit.json 已废弃）。
+    """
     data = {
         "channels": {
             "conv-a": {
@@ -45,9 +48,23 @@ def audit_json(tmp_path, monkeypatch):
             },
         }
     }
-    p = tmp_path / "audit.json"
+    # V7: state 落在 <project_dir>/plugins/audit/state.json
+    project_path = tmp_path / "audit-test"
+    audit_dir = project_path / "plugins" / "audit"
+    audit_dir.mkdir(parents=True)
+    p = audit_dir / "state.json"
     p.write_text(json.dumps(data), encoding="utf-8")
-    monkeypatch.setenv("CS_DATA_DIR", str(tmp_path))
+    # 构造最小合法 project（main callback 会 load_project_config）
+    (project_path / "config.toml").write_text("", encoding="utf-8")
+
+    # Patch app.py 级别的 resolve/load（module-level import）
+    from zchat.cli import app as _app
+    monkeypatch.setattr(_app, "resolve_project", lambda explicit=None: "audit-test")
+    monkeypatch.setattr(_app, "load_project_config", lambda name: {})
+    # Patch paths.project_dir（audit_cmd 函数内 import，monkeypatch 生效）
+    from zchat.cli import paths as _paths
+    monkeypatch.setattr(_paths, "project_dir",
+                        lambda name: project_path if name == "audit-test" else Path("/nonexistent"))
     return p
 
 
@@ -116,8 +133,16 @@ def test_audit_export_to_file(audit_json, tmp_path):
 
 
 def test_audit_status_missing_file(tmp_path, monkeypatch):
-    """audit.json 不存在 → 返回空聚合。"""
-    monkeypatch.setenv("CS_DATA_DIR", str(tmp_path))
+    """state.json 不存在 → 返回空聚合。"""
+    project_path = tmp_path / "empty-proj"
+    project_path.mkdir()
+    (project_path / "config.toml").write_text("", encoding="utf-8")
+    from zchat.cli import app as _app
+    monkeypatch.setattr(_app, "resolve_project", lambda explicit=None: "empty-proj")
+    monkeypatch.setattr(_app, "load_project_config", lambda name: {})
+    from zchat.cli import paths as _paths
+    monkeypatch.setattr(_paths, "project_dir",
+                        lambda name: project_path if name == "empty-proj" else Path("/nonexistent"))
     result = runner.invoke(app, ["audit", "status"])
     assert result.exit_code == 0
     assert "total channels: 0" in result.output

--- a/zchat/cli/audit_cmd.py
+++ b/zchat/cli/audit_cmd.py
@@ -1,40 +1,36 @@
-"""audit CLI — 读 audit.json 输出状态和报告。
+"""audit CLI — 读 audit plugin 的 state.json 输出状态和报告。
 
 管理型 agent 通过 run_zchat_cli(["audit", "status"]) 或 ["audit", "report"] 取数。
 
-audit.json 由 CS 的 AuditPlugin 持久化。CLI 只读，不写。
+V7 (2026-04-22) 起：audit plugin state 路径改为
+    <project_dir>/plugins/audit/state.json
+(V6 的 <project_dir>/audit.json 已废弃。如果 plugins.toml 显式 override 了
+audit.data_dir，本 CLI 仍读默认路径——生产环境 operator 不应手动 override。)
 """
 
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Optional
 
 import typer
 
 
-audit_app = typer.Typer(name="audit", help="Read audit.json for channel statistics.")
+audit_app = typer.Typer(name="audit", help="Read audit plugin state for channel statistics.")
 
 
 def _resolve_audit_path(ctx: typer.Context) -> Path:
-    """定位 audit.json。
-    优先顺序：
-      1. $CS_DATA_DIR/audit.json
-      2. project_dir 里的 audit.json
-      3. ./audit.json
-    """
-    env_path = os.environ.get("CS_DATA_DIR")
-    if env_path:
-        return Path(env_path) / "audit.json"
+    """定位 audit plugin state.json。
 
+    V7 路径：<project_dir>/plugins/audit/state.json
+    """
     project_name = ctx.obj.get("project") if ctx.obj else None
     if project_name:
         from zchat.cli.paths import project_dir
-        return Path(project_dir(project_name)) / "audit.json"
+        return Path(project_dir(project_name)) / "plugins" / "audit" / "state.json"
 
-    return Path("audit.json")
+    return Path("plugins/audit/state.json")
 
 
 def _load_state(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
V6→V7 遗漏: zchat audit CLI 还读 V6 路径 audit.json。修正为 plugins/audit/state.json + 删 CS_DATA_DIR env 支持 + 测试 fixture 同步。304 unit passed。