### PR TITLE
feat(cli): bot add --credential · 简化凭证流程

### DIFF
--- a/docs/guide/002-quick-start.md
+++ b/docs/guide/002-quick-start.md
@@ -50,15 +50,32 @@ ls ~/.zchat/projects/prod/   # config.toml + 空 routing.toml
 - 权限：`im:message`、`im:chat`、`im:message.group_at_msg`
 - 启用 WSS 长连接
 
+**推荐 V7+ 用法**（先准备 credential 文件再注册，secret 不进 shell history）：
+
 ```bash
-zchat bot add customer --app-id cli_xxx --app-secret yyy \
-    --template fast-agent --lazy        # lazy: 拉新群自动懒创建 channel + agent
+# 1. 写 credential 文件
+mkdir -p ~/.zchat/projects/prod/credentials
+cat > ~/.zchat/projects/prod/credentials/customer.json <<'EOF'
+{"app_id": "cli_xxx", "app_secret": "yyy"}
+EOF
+# 同理写 admin.json / squad.json
 
-zchat bot add admin --app-id cli_zzz --app-secret www \
-    --template admin-agent
+# 2. 注册 bot（自动检测 credentials/<name>.json）
+zchat bot add customer --template fast-agent --lazy   # lazy: 拉新群自动懒创建 channel + agent
+zchat bot add admin    --template admin-agent
+zchat bot add squad    --template squad-agent --supervises customer
+```
 
-zchat bot add squad --app-id cli_aaa --app-secret bbb \
-    --template squad-agent --supervises customer
+**显式指定 credential 路径**：
+
+```bash
+zchat bot add customer --credential /path/to/customer.json --template fast-agent --lazy
+```
+
+**老用法**（兼容保留，secret 进 shell history 不推荐）：
+
+```bash
+zchat bot add customer --app-id cli_xxx --app-secret yyy --template fast-agent --lazy
 ```
 
 ## 3. 注册 channel

--- a/docs/guide/006-routing-config.md
+++ b/docs/guide/006-routing-config.md
@@ -85,8 +85,14 @@ supervises = [
 zchat CLI 是 routing.toml 唯一合法 writer：
 
 ```bash
-zchat bot add <name> --app-id X --app-secret Y \
-    --template fast-agent --lazy [--supervises a,b]
+# 推荐: 先写 credentials/<name>.json {"app_id":"X","app_secret":"Y"}，再注册
+zchat bot add <name> --template fast-agent --lazy [--supervises a,b]
+
+# 或显式指定 credential 路径
+zchat bot add <name> --credential <path>.json --template fast-agent --lazy
+
+# 老用法兼容（secret 进 shell history，不推荐）
+zchat bot add <name> --app-id X --app-secret Y --template fast-agent --lazy
 
 zchat bot list
 zchat bot remove <name>

--- a/docs/guide/007-plugin-guide.md
+++ b/docs/guide/007-plugin-guide.md
@@ -157,7 +157,7 @@ V6 时代的 `CS_DATA_DIR` 环境变量兜底在 V7 **删除**（eval-doc-014 D-
 ~/.zchat/projects/<proj>/
 ├── config.toml             ← CLI 写，CLI 读
 ├── routing.toml            ← CLI 写；CS routing_watcher 读 + hot-reload
-├── credentials/            ← CLI 写（zchat bot add --app-secret）；bridge 读
+├── credentials/            ← 用户或 CLI 写（V7+ `zchat bot add --credential` / 兼容 `--app-secret`）；bridge 读
 ├── audit.json              ← AuditPlugin 读写
 ├── activation-state.json   ← ActivationPlugin 读写
 ├── cs.log / bridge-*.log   ← 各自进程 stdout redirect

--- a/tests/unit/test_channel_cmd.py
+++ b/tests/unit/test_channel_cmd.py
@@ -421,3 +421,78 @@ def test_agent_join_normalizes_channel_name(project_with_channel, monkeypatch):
     state = _read_agent_state(str(project_with_channel / "projects"))
     channels = state["agents"]["alice-helper"]["channels"]
     assert "#support" in channels
+
+
+# ---------------------------------------------------------------------------
+# CLI: bot add credential modes (V7)
+# ---------------------------------------------------------------------------
+
+def test_bot_add_with_credential_file(project):
+    """--credential <path>: 从 JSON 读 app_id + app_secret，routing.toml 写 credential_file。"""
+    pdir = project / "projects" / "testproj"
+    cred_dir = pdir / "credentials"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    (cred_dir / "customer.json").write_text(
+        json.dumps({"app_id": "cli_credapp", "app_secret": "secret123"}), encoding="utf-8"
+    )
+    result = runner.invoke(
+        app,
+        ["bot", "add", "customer", "--credential", "credentials/customer.json",
+         "--template", "fast-agent", "--lazy"],
+    )
+    assert result.exit_code == 0, result.output
+    data = load_routing(pdir)
+    bot = data["bots"]["customer"]
+    assert bot["app_id"] == "cli_credapp"
+    assert bot["credential_file"] == "credentials/customer.json"
+    assert bot["default_agent_template"] == "fast-agent"
+    assert bot["lazy_create_enabled"] is True
+
+
+def test_bot_add_auto_detects_default_credential(project):
+    """既不传 --credential 也不传 --app-id 时，自动检测 credentials/<name>.json。"""
+    pdir = project / "projects" / "testproj"
+    cred_dir = pdir / "credentials"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    (cred_dir / "admin.json").write_text(
+        json.dumps({"app_id": "cli_autoapp", "app_secret": "autosecret"}), encoding="utf-8"
+    )
+    result = runner.invoke(app, ["bot", "add", "admin", "--template", "admin-agent"])
+    assert result.exit_code == 0, result.output
+    assert "Using default credential file" in result.output
+    data = load_routing(pdir)
+    bot = data["bots"]["admin"]
+    assert bot["app_id"] == "cli_autoapp"
+    assert bot["credential_file"] == "credentials/admin.json"
+
+
+def test_bot_add_credential_mutex_with_app_id(project):
+    """--credential 和 --app-id 互斥。"""
+    pdir = project / "projects" / "testproj"
+    cred_dir = pdir / "credentials"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    (cred_dir / "x.json").write_text(json.dumps({"app_id": "a"}), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["bot", "add", "x", "--credential", "credentials/x.json",
+         "--app-id", "cli_otherone"],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_bot_add_no_credential_no_app_id_fails(project):
+    """既无 --credential 又无 --app-id 又无默认 credential 文件 → 报错。"""
+    result = runner.invoke(app, ["bot", "add", "missing"])
+    assert result.exit_code != 0
+    assert "must provide" in result.output
+
+
+def test_bot_add_credential_file_missing_fails(project):
+    """--credential 指向的文件不存在 → 报错。"""
+    result = runner.invoke(
+        app,
+        ["bot", "add", "ghost", "--credential", "credentials/ghost.json"],
+    )
+    assert result.exit_code != 0
+    assert "credential file not found" in result.output

--- a/zchat/cli/app.py
+++ b/zchat/cli/app.py
@@ -1398,9 +1398,13 @@ def cmd_channel_set_entry(
 def cmd_bot_add(
     ctx: typer.Context,
     name: str = typer.Argument(..., help="Bot name (logical identifier used in routing.toml)"),
-    app_id: str = typer.Option(..., "--app-id", help="External platform app id"),
+    credential: Optional[str] = typer.Option(None, "--credential", "-c",
+                                              help="Path to credential JSON (with app_id + app_secret). "
+                                                   "Relative to project dir; defaults to credentials/<name>.json if exists."),
+    app_id: Optional[str] = typer.Option(None, "--app-id",
+                                          help="External platform app id (alternative to --credential; legacy)"),
     app_secret: Optional[str] = typer.Option(None, "--app-secret",
-                                              help="App secret (written to credentials/<name>.json)"),
+                                              help="App secret (only with --app-id; writes credentials/<name>.json)"),
     template: Optional[str] = typer.Option(None, "--template",
                                             help="Default agent template for lazy-create"),
     lazy: bool = typer.Option(False, "--lazy",
@@ -1408,27 +1412,91 @@ def cmd_bot_add(
     supervises: Optional[str] = typer.Option(None, "--supervises",
                                               help="Comma-separated bot names this bot monitors (supervision). V7+ 支持 tag:/pattern: 前缀"),
 ):
-    """Register a bot in routing.toml [bots]. Optionally write secret to credentials/."""
+    """Register a bot in routing.toml [bots].
+
+    Three ways to provide credentials (in priority order):
+
+      1. --credential <path> (recommended): read app_id + app_secret from
+         existing JSON file. Path is relative to project dir.
+
+      2. Auto-detect: if neither --credential nor --app-id is given, looks
+         for credentials/<name>.json in the project dir.
+
+      3. --app-id <id> [--app-secret <secret>] (legacy): if --app-secret is
+         given, zchat writes credentials/<name>.json for you.
+    """
     from zchat.cli.routing import add_bot as routing_add_bot
+    import json as _json
+    from pathlib import Path as _Path
+
     project_name = ctx.obj.get("project") if ctx.obj else None
     if not project_name:
         typer.echo("Error: No project selected.", err=True)
         raise typer.Exit(1)
 
-    from pathlib import Path as _Path
     pdir = _Path(project_dir(project_name))
     cred_rel: Optional[str] = None
-    if app_secret:
-        cred_dir = pdir / "credentials"
-        cred_dir.mkdir(parents=True, exist_ok=True)
-        cred_path = cred_dir / f"{name}.json"
-        import json as _json
-        cred_path.write_text(
-            _json.dumps({"app_id": app_id, "app_secret": app_secret}, indent=2),
-            encoding="utf-8",
+    resolved_app_id: Optional[str] = None
+
+    # Mutual exclusion
+    if credential and (app_id or app_secret):
+        typer.echo("Error: --credential is mutually exclusive with --app-id/--app-secret.", err=True)
+        raise typer.Exit(1)
+
+    # Auto-detect default credential file if neither path is given
+    if not credential and not app_id:
+        default_cred = pdir / "credentials" / f"{name}.json"
+        if default_cred.is_file():
+            credential = f"credentials/{name}.json"
+            typer.echo(f"Using default credential file: {credential}")
+
+    # Mode 1: --credential (recommended)
+    if credential:
+        cred_path = _Path(credential)
+        if not cred_path.is_absolute():
+            cred_path = pdir / credential
+        if not cred_path.is_file():
+            typer.echo(f"Error: credential file not found: {cred_path}", err=True)
+            raise typer.Exit(1)
+        try:
+            cred_data = _json.loads(cred_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            typer.echo(f"Error: failed to parse credential JSON ({cred_path}): {e}", err=True)
+            raise typer.Exit(1)
+        resolved_app_id = cred_data.get("app_id")
+        if not resolved_app_id:
+            typer.echo(f"Error: credential JSON missing 'app_id' field: {cred_path}", err=True)
+            raise typer.Exit(1)
+        if not cred_data.get("app_secret"):
+            typer.echo(
+                f"Warning: credential JSON missing 'app_secret'; bridge may fail to authenticate.",
+                err=True,
+            )
+        try:
+            cred_rel = str(cred_path.relative_to(pdir))
+        except ValueError:
+            cred_rel = str(cred_path)  # absolute path fallback
+
+    # Mode 3: --app-id legacy path
+    elif app_id:
+        resolved_app_id = app_id
+        if app_secret:
+            cred_dir = pdir / "credentials"
+            cred_dir.mkdir(parents=True, exist_ok=True)
+            cred_path = cred_dir / f"{name}.json"
+            cred_path.write_text(
+                _json.dumps({"app_id": app_id, "app_secret": app_secret}, indent=2),
+                encoding="utf-8",
+            )
+            cred_rel = f"credentials/{name}.json"
+            typer.echo(f"Wrote secret to {cred_path}")
+    else:
+        typer.echo(
+            "Error: must provide --credential <path>, or place credentials/"
+            f"{name}.json in project dir, or use legacy --app-id <id>.",
+            err=True,
         )
-        cred_rel = f"credentials/{name}.json"
-        typer.echo(f"Wrote secret to {cred_path}")
+        raise typer.Exit(1)
 
     supervises_list: Optional[list[str]] = None
     if supervises:
@@ -1436,7 +1504,7 @@ def cmd_bot_add(
     try:
         routing_add_bot(
             pdir, name,
-            app_id=app_id,
+            app_id=resolved_app_id,
             credential_file=cred_rel,
             default_agent_template=template,
             lazy_create_enabled=lazy,
@@ -1445,7 +1513,7 @@ def cmd_bot_add(
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
-    msg = f"Bot '{name}' registered (app_id={app_id}, lazy={lazy}"
+    msg = f"Bot '{name}' registered (app_id={resolved_app_id}, lazy={lazy}"
     if supervises_list:
         msg += f", supervises={supervises_list}"
     typer.echo(msg + ").")


### PR DESCRIPTION
## Summary

V7 之前 \`zchat bot add\` 必传 \`--app-id\`、\`--app-secret\` 进 shell history。新设计：
- **推荐**：\`--credential <path>\`（从 JSON 读）
- **自动检测**：不传任何凭证参数时，找 \`credentials/<name>.json\`
- **互斥**：\`--credential\` 不能和 \`--app-id\`/\`--app-secret\` 共用
- **兼容**：老 \`--app-id\` 用法保留

## 改动

- \`zchat/cli/app.py\` cmd_bot_add 重写
- 5 new test cases (all green)
- docs/guide 002/006/007 三处 bot add 例子同步

## Test Plan
- [x] 5 new test pass
- [x] 309 unit total pass (0 regression)
- [ ] 真机部署 demo（用户在 server 上跑 git pull + zchat bot add --template ...）