### PR TITLE
feat(cli): zchat agent start — 拉回 offline agent

### DIFF
--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -21,6 +21,62 @@ def test_scope_agent_name():
     assert mgr.scoped("alice-helper") == "alice-alice-helper"
 
 
+def test_start_brings_offline_agent_online(tmp_path, monkeypatch):
+    """`agent start` 应该用 state.json 里的 channels/type 重新拉起 offline agent。"""
+    import pytest
+    mgr = _make_manager(
+        state_file=str(tmp_path / "agents.json"),
+        project_dir=str(tmp_path),
+    )
+    mgr._agents["alice-helper"] = {
+        "type": "fast-agent",
+        "status": "offline",
+        "channels": ["#conv-001"],
+        "workspace": str(tmp_path / "agents" / "alice-helper"),
+        "created_at": 0,
+    }
+    seen = {}
+
+    def fake_create(name, channels, agent_type):
+        seen["name"] = name
+        seen["channels"] = channels
+        seen["agent_type"] = agent_type
+        return mgr._agents[mgr.scoped(name)]
+
+    monkeypatch.setattr(mgr, "create", fake_create)
+    mgr.start("helper")
+    assert seen == {
+        "name": "helper",
+        "channels": ["#conv-001"],
+        "agent_type": "fast-agent",
+    }
+
+
+def test_start_rejects_running_agent(tmp_path):
+    """start 不应该在 agent 还 running 时拉，应该报错让用户用 restart。"""
+    import pytest
+    mgr = _make_manager(
+        state_file=str(tmp_path / "agents.json"),
+        project_dir=str(tmp_path),
+    )
+    mgr._agents["alice-helper"] = {
+        "type": "claude",
+        "status": "running",
+        "channels": ["#general"],
+        "workspace": str(tmp_path / "agents" / "alice-helper"),
+        "created_at": 0,
+    }
+    with pytest.raises(ValueError, match="not offline"):
+        mgr.start("helper")
+
+
+def test_start_unknown_agent_raises(tmp_path):
+    import pytest
+    mgr = _make_manager(state_file=str(tmp_path / "agents.json"))
+    with pytest.raises(ValueError, match="Unknown agent"):
+        mgr.start("ghost")
+
+
 def test_create_workspace_exists():
     """create_workspace should create a directory."""
     mgr = _make_manager(state_file="/tmp/test-agents-ws2.json")

--- a/zchat/cli/agent_manager.py
+++ b/zchat/cli/agent_manager.py
@@ -151,6 +151,23 @@ class AgentManager:
         self.stop(name)
         self.create(name, channels=channels, agent_type=agent_type)
 
+    def start(self, name: str):
+        """Bring an offline agent back online (uses config persisted in state.json)."""
+        scoped = self.scoped(name)
+        agent = self._agents.get(scoped)
+        if not agent:
+            raise ValueError(
+                f"Unknown agent: {scoped}. Use `agent create` to register a new one."
+            )
+        if agent["status"] != "offline":
+            raise ValueError(
+                f"{scoped} is not offline (status={agent['status']}). "
+                f"Use `agent restart` to recreate."
+            )
+        channels = list(agent.get("channels", self.default_channels))
+        agent_type = agent.get("type", self.default_type)
+        self.create(name, channels=channels, agent_type=agent_type)
+
     def list_agents(self) -> dict[str, dict]:
         """Return all agents with refreshed status."""
         for name, info in self._agents.items():

--- a/zchat/cli/app.py
+++ b/zchat/cli/app.py
@@ -1170,6 +1170,16 @@ def cmd_agent_restart(ctx: typer.Context, name: str = typer.Argument(...)):
     mgr.restart(name)
     typer.echo(f"Restarted {scoped}")
 
+
+@agent_app.command("start")
+def cmd_agent_start(ctx: typer.Context, name: str = typer.Argument(...)):
+    """Bring an offline agent back online (uses config from state.json)."""
+
+    mgr = _get_agent_manager(ctx)
+    scoped = mgr.scoped(name)
+    mgr.start(name)
+    typer.echo(f"Started {scoped}")
+
 @agent_app.command("focus")
 def cmd_agent_focus(
     ctx: typer.Context,


### PR DESCRIPTION
## Summary

之前没办法把已注册但 offline 的 agent 直接拉 online：
- \`agent stop\` 拒绝 offline（合理）
- \`agent restart\` 调 \`stop()\` 第一步就抛 \"already offline\"
- \`agent create\` 是注册新 agent，对已存在 offline 的也会报存在

加专用 \`zchat agent start <name>\` 命令：从 state.json 读出 channels + type，调用 create 重新拉起。restart 语义保持\"先停再起\"不变。

## 命令对照表

| 状态 | 命令 |
|------|------|
| 新 agent | \`agent create <name> --type <t> --channel <ch>\` |
| running agent → 重启 | \`agent restart <name>\` |
| offline agent → 拉回 | \`agent start <name>\` （新增）|
| running agent → 停掉 | \`agent stop <name>\` |

## Test plan

- [x] \`uv run pytest tests/unit/test_agent_manager.py\` — 22/22 passed (3 个新测试)
- [x] start 拒绝已 running 的 agent
- [x] start unknown agent 报错
- [x] start 用 state.json 里的 channels/type 调 create

🤖 Generated with [Claude Code](https://claude.com/claude-code)