### PR TITLE
fix(agent): auto-confirm 连续 prompt + 消 remember plugin 刷屏

### DIFF
--- a/zchat/cli/agent_manager.py
+++ b/zchat/cli/agent_manager.py
@@ -330,7 +330,17 @@ class AgentManager:
 
         Uses dump-screen polling instead of subscribe to avoid leaving
         orphan zellij processes that block the parent from exiting.
+
+        Dedup by screen-content hash (not pattern): Claude Code can show
+        consecutive prompts that share wording (e.g., both --dangerously-skip
+        and --dangerously-load prompts contain "local development"). Dedup
+        by pattern would miss the second one.
         """
+        import hashlib
+
+        def _screen_digest(text: str) -> str:
+            return hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()
+
         def _watch():
             pane_id = None
             # Wait briefly for tab to be ready
@@ -343,32 +353,41 @@ class AgentManager:
                 return
 
             deadline = time.time() + timeout
-            # Patterns that appear in Claude Code startup prompts
-            # （新版措辞含 "I am using this for local development" / --dangerously-load-... 提示）
+            # Patterns that appear in Claude Code startup prompts (all lowercased)
             confirm_patterns = [
                 "i trust this folder",
                 "local development",
                 "enter to confirm",
                 "development channels",
-                "development-channels",   # --dangerously-load-development-channels 提示
-                "dangerously-load",        # 兜底通用
-                "i am using this",         # 新版 claude 主选项措辞
+                "development-channels",   # --dangerously-load-development-channels
+                "dangerously-load",
+                "dangerously-skip",
+                "i am using this",
+                "press enter to continue",
+                "press enter to accept",
+                "prompt injection risks",  # 新版 load-channels 的警告措辞
             ]
-            confirmed: set[str] = set()
+            last_confirmed_digest: str | None = None
             while time.time() < deadline:
                 screen = zellij.dump_screen(self._session_name, pane_id).lower()
                 if not screen:
                     time.sleep(1)
                     continue
-                for pattern in confirm_patterns:
-                    if pattern in screen and pattern not in confirmed:
-                        zellij.send_keys(self._session_name, pane_id, "Enter")
-                        confirmed.add(pattern)
-                        time.sleep(1)
-                        break
-                # Stop polling once Claude Code is ready (INSERT mode visible)
+                # Stop polling once Claude Code is ready (INSERT mode visible
+                # in status bar — banner like "prompt injection risks" still
+                # counts as pre-ready if no INSERT yet).
                 if "insert" in screen:
                     break
+                digest = _screen_digest(screen[-2000:])   # 屏幕尾部就够，头部滚动无关
+                if digest == last_confirmed_digest:
+                    # Screen hasn't changed since last confirm — waiting for next
+                    time.sleep(1)
+                    continue
+                if any(p in screen for p in confirm_patterns):
+                    zellij.send_keys(self._session_name, pane_id, "Enter")
+                    last_confirmed_digest = digest
+                    time.sleep(1.5)
+                    continue
                 time.sleep(1)
 
         thread = threading.Thread(target=_watch, daemon=True)

--- a/zchat/cli/templates/admin-agent/start.sh
+++ b/zchat/cli/templates/admin-agent/start.sh
@@ -34,7 +34,7 @@ if [ -f "$TEMPLATE_DIR/soul.md" ]; then
 fi
 
 # --- Copy skills/ to .claude/skills/ ---
-mkdir -p .claude
+mkdir -p .claude .remember/logs   # .remember: 消 global remember plugin 的 hook-errors.log 警告
 rm -rf .claude/skills
 if [ -d "$TEMPLATE_DIR/skills" ]; then
   cp -r "$TEMPLATE_DIR/skills" .claude/skills

--- a/zchat/cli/templates/claude/start.sh
+++ b/zchat/cli/templates/claude/start.sh
@@ -33,7 +33,7 @@ if [ -f "$TEMPLATE_DIR/soul.md" ]; then
 fi
 
 # --- Claude settings with SessionStart hook ---
-mkdir -p .claude
+mkdir -p .claude .remember/logs   # .remember: 消 global remember plugin 的 hook-errors.log 警告
 READY_PATH="${ZCHAT_PROJECT_DIR}/agents/${AGENT_NAME}.ready"
 
 jq -n \

--- a/zchat/cli/templates/deep-agent/start.sh
+++ b/zchat/cli/templates/deep-agent/start.sh
@@ -34,7 +34,7 @@ if [ -f "$TEMPLATE_DIR/soul.md" ]; then
 fi
 
 # --- Copy skills/ to .claude/skills/ ---
-mkdir -p .claude
+mkdir -p .claude .remember/logs   # .remember: 消 global remember plugin 的 hook-errors.log 警告
 rm -rf .claude/skills
 if [ -d "$TEMPLATE_DIR/skills" ]; then
   cp -r "$TEMPLATE_DIR/skills" .claude/skills

--- a/zchat/cli/templates/fast-agent/start.sh
+++ b/zchat/cli/templates/fast-agent/start.sh
@@ -34,7 +34,7 @@ if [ -f "$TEMPLATE_DIR/soul.md" ]; then
 fi
 
 # --- Copy skills/ to .claude/skills/ (Claude Code 按 description 自动触发) ---
-mkdir -p .claude
+mkdir -p .claude .remember/logs   # .remember: 消 global remember plugin 的 hook-errors.log 警告
 rm -rf .claude/skills
 if [ -d "$TEMPLATE_DIR/skills" ]; then
   cp -r "$TEMPLATE_DIR/skills" .claude/skills

--- a/zchat/cli/templates/squad-agent/start.sh
+++ b/zchat/cli/templates/squad-agent/start.sh
@@ -34,7 +34,7 @@ if [ -f "$TEMPLATE_DIR/soul.md" ]; then
 fi
 
 # --- Copy skills/ to .claude/skills/ ---
-mkdir -p .claude
+mkdir -p .claude .remember/logs   # .remember: 消 global remember plugin 的 hook-errors.log 警告
 rm -rf .claude/skills
 if [ -d "$TEMPLATE_DIR/skills" ]; then
   cp -r "$TEMPLATE_DIR/skills" .claude/skills


### PR DESCRIPTION
## 两个 bug

### 1. auto-confirm 对连续 prompt 失效

原实现 pattern-based 去重（每个 pattern 只送一次 Enter）。Claude Code 新版
两个 prompt 都含 \"local development\" 字样：
- \`--dangerously-skip-permissions\` 的 \"I trust this folder / local development\"
- \`--dangerously-load-development-channels\` 的 \"local-development only\" 警告

第二个 prompt 的 \"local development\" pattern 被 dedup 跳过 → 留在屏幕等
手按。改成按屏幕内容 hash 去重：同一个屏幕快照只送一次 Enter，屏幕变了
就可以再送。

同时补几个新措辞 pattern：\`press enter to continue\` / \`dangerously-skip\`
/ \`prompt injection risks\`。

### 2. remember plugin 刷屏

用户全局 \`~/.claude/settings.json\` enable 了 \`remember@claude-plugins-official\`。
agent 启动时 hook 触发，plugin 往 \`<agent-workspace>/.remember/logs/hook-errors.log\`
写日志，目录不存在就刷：

\`\`\`
Failed with non-blocking status code: /bin/sh: /Users/.../agents/linyilun-admin-0/.remember/logs/hook-errors.log: No such file or directory
\`\`\`

5 个 agent template 的 \`start.sh\` 在 \`mkdir -p .claude\` 同一行补
\`.remember/logs\`。非阻塞但消掉刷屏。

## Test plan

- [x] \`uv run pytest tests/unit/test_agent_manager.py\` — 22/22 passed
- [ ] server 上 pull 后 \`zchat down && zchat up --only ...\` 验证两个 agent 启动无需手按 + 无 .remember 刷屏

🤖 Generated with [Claude Code](https://claude.com/claude-code)