### PR TITLE
fix(agent): auto-confirm 用 cooldown 替代 hash 去重

### DIFF
--- a/zchat/cli/agent_manager.py
+++ b/zchat/cli/agent_manager.py
@@ -331,16 +331,13 @@ class AgentManager:
         Uses dump-screen polling instead of subscribe to avoid leaving
         orphan zellij processes that block the parent from exiting.
 
-        Dedup by screen-content hash (not pattern): Claude Code can show
-        consecutive prompts that share wording (e.g., both --dangerously-skip
-        and --dangerously-load prompts contain "local development"). Dedup
-        by pattern would miss the second one.
+        Dedup by cooldown (not pattern/hash): Claude Code shows consecutive
+        prompts that can look nearly identical (both --dangerously-skip and
+        --dangerously-load prompts share footer "1. I am using this for local
+        development / 2. Exit / Enter to confirm"). Hash-based dedup on the
+        tail would mistake them for the same screen. Cooldown just caps the
+        Enter send rate — spurious extras are harmless (terminal dedup).
         """
-        import hashlib
-
-        def _screen_digest(text: str) -> str:
-            return hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()
-
         def _watch():
             pane_id = None
             # Wait briefly for tab to be ready
@@ -365,29 +362,22 @@ class AgentManager:
                 "i am using this",
                 "press enter to continue",
                 "press enter to accept",
-                "prompt injection risks",  # 新版 load-channels 的警告措辞
+                "loading development channels",
             ]
-            last_confirmed_digest: str | None = None
+            COOLDOWN = 2.5    # 秒；两次 Enter 最小间隔
+            last_sent_at = 0.0
             while time.time() < deadline:
                 screen = zellij.dump_screen(self._session_name, pane_id).lower()
                 if not screen:
                     time.sleep(1)
                     continue
-                # Stop polling once Claude Code is ready (INSERT mode visible
-                # in status bar — banner like "prompt injection risks" still
-                # counts as pre-ready if no INSERT yet).
+                # Stop polling once Claude Code is ready (INSERT mode in status bar)
                 if "insert" in screen:
                     break
-                digest = _screen_digest(screen[-2000:])   # 屏幕尾部就够，头部滚动无关
-                if digest == last_confirmed_digest:
-                    # Screen hasn't changed since last confirm — waiting for next
-                    time.sleep(1)
-                    continue
-                if any(p in screen for p in confirm_patterns):
+                now = time.time()
+                if any(p in screen for p in confirm_patterns) and (now - last_sent_at) >= COOLDOWN:
                     zellij.send_keys(self._session_name, pane_id, "Enter")
-                    last_confirmed_digest = digest
-                    time.sleep(1.5)
-                    continue
+                    last_sent_at = now
                 time.sleep(1)
 
         thread = threading.Thread(target=_watch, daemon=True)


### PR DESCRIPTION
补刀 PR #76。

## 问题

上个 fix 用 \`screen[-2000:]\` hash 去重。两个连续 prompt（\`--dangerously-skip\`
+ \`--dangerously-load-development-channels\`）的 UI 尾部几乎一样：

\`\`\`
❯ 1. I am using this for local development
  2. Exit
Enter to confirm · Esc to cancel
\`\`\`

尾部 hash 相同 → 第二个 prompt 被误判已处理 → Enter 不送。

## 修法

改成时间 cooldown（2.5s）：每次匹配 pattern 就送 Enter，两次最小间隔 2.5s。

- pattern 持续 → 被速率限制不刷屏
- prompt 切换 → ≥2.5s 后下一次匹配送 Enter
- 误送 Enter 对已 pass 的 prompt 无害（terminal 丢弃）

## Test plan

- [x] \`pytest tests/unit/test_agent_manager.py\` — 22/22 passed
- [ ] server pull + 重启 agent，验证两个 prompt 都自动过

🤖 Generated with [Claude Code](https://claude.com/claude-code)