### PR TITLE
fix(test): test_layout mock leak on Python 3.14+ CI

### DIFF
--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -63,7 +63,7 @@ def test_generate_layout_has_zchat_status_plugin_when_wasm_present():
     """Layout 包含 zchat-status wasm 插件（仅当 wasm 文件存在时）。"""
     config = {}
     state = {"agents": {}}
-    with patch("zchat.cli.layout.os.path.isfile", return_value=True):
+    with patch("zchat.cli.layout._wasm_present", return_value=True):
         kdl = generate_layout(config, state)
     assert "zchat-status.wasm" in kdl
 
@@ -72,7 +72,7 @@ def test_generate_layout_skips_zchat_status_when_wasm_missing():
     """Layout 不包含 wasm 插件（wasm 文件不存在）。"""
     config = {}
     state = {"agents": {}}
-    with patch("zchat.cli.layout.os.path.isfile", return_value=False):
+    with patch("zchat.cli.layout._wasm_present", return_value=False):
         kdl = generate_layout(config, state)
     assert "zchat-status.wasm" not in kdl
 

--- a/zchat/cli/layout.py
+++ b/zchat/cli/layout.py
@@ -17,6 +17,17 @@ def _plugins_dir() -> str:
     return str(paths.plugins_dir())
 
 
+def _wasm_present(wasm_path: str) -> bool:
+    """Indirection over os.path.isfile so tests can mock this narrowly.
+
+    Patching `os.path.isfile` directly leaks into pathlib.Path.is_file()
+    on Python 3.14+ (which now delegates to os.path.isfile internally),
+    breaking other code paths that incidentally check Path.is_file (e.g.
+    paths._load_config_paths). Patch this helper instead.
+    """
+    return os.path.isfile(wasm_path)
+
+
 def generate_layout(
     config: dict,
     state: dict,
@@ -39,7 +50,7 @@ def generate_layout(
     lines.append("        children")
     plugins = _plugins_dir()
     wasm_path = os.path.join(plugins, "zchat-status.wasm")
-    if os.path.isfile(wasm_path):
+    if _wasm_present(wasm_path):
         lines.append('        pane size=1 borderless=true {')
         lines.append(f'            plugin location="file:{wasm_path}"')
         lines.append("        }")


### PR DESCRIPTION
## Background

CI tests have been failing on `test_generate_layout_has_zchat_status_plugin_when_wasm_present` since commit `0e3f78c` introduced the wasm-presence check + corresponding `patch("zchat.cli.layout.os.path.isfile", return_value=True)` in the test.

## Root cause

Python 3.14 changed `pathlib.Path.is_file()` implementation to delegate to `os.path.isfile()`. Patching `os.path.isfile` (even via the module-attribute path `zchat.cli.layout.os.path.isfile`) is a **global patch** because `os.path` is a singleton module. This leaks into any `Path.is_file()` call elsewhere — breaking `paths._load_config_paths()` which checks `~/.zchat/config.toml` existence:

\`\`\`
zchat/cli/paths.py:43: FileNotFoundError: '/Users/runner/.zchat/config.toml'
\`\`\`

(is_file falsely returns True from mock leak → walks past the existence guard → open() fails)

Local Linux Python 3.13.5 doesn't reproduce because Path.is_file still uses os.stat directly there.

## Fix

Wrap the isfile call in `layout._wasm_present()` private helper. Patch that narrow target in tests instead of patching `os.path.isfile` globally.

- production behavior unchanged (1-line indirection, same return value)
- test behavior unchanged (still verifies wasm presence/absence cases)
- mock no longer leaks to Path.is_file in any other code path