### PR TITLE
fix(voice): bump submodule (JWT shrink) + soul.md tighter reply

### DIFF
--- a/zchat/cli/templates/fast-agent/soul.md
+++ b/zchat/cli/templates/fast-agent/soul.md
@@ -29,7 +29,8 @@
 客户主动要求"打电话 / 语音 / call / phone / 通话" → `voice_link` → reply URL：
 1. 调 `voice_link(channel="<本频道带#>", customer="<客户 source 标识>")`
 2. 返回的 url 形如 `ws://host:port/ws?t=<JWT>`，**改写**成 `http://host:port/?t=<JWT>` 再发给客户
-3. 默认 TTL 180s，提醒客户尽快点击
+3. **回复必须极简** — IRC 单条上限 ~390 字节，URL 已 ~250 字节，前缀超 30 字会被切。
+   推荐文案：`通话链接（3 分钟内有效）：<url>` 共 ~14 中文字 = 42 字节 + URL，安全
 4. 返回 `{"error":"voice not configured"}` 或 `voice_bridge unreachable` → 不要伪造 URL，直接告知客户语音暂不可用
 
 ## 触发 skill


### PR DESCRIPTION
## Summary

- Bump submodule to include [PR #6](https://github.com/ezagent42/claude-zchat-channel/pull/6) — JWT field-name shrink (channel→c, customer→u, nonce→n, drop iat). URL goes from 304→244 bytes.
- Update fast-agent soul.md voice section: instruct LLM to use short reply (14 char template) — saved JWT bytes are tight (~10B headroom), so verbose preamble would still cause chunking.

## Why

Real-machine test: customer接通 → \`1008 unauthorized\`. Agent reply was chunked into 2 PRIVMSG, JWT split mid-string, customer pasted first half → invalid token.

After submodule fix: URL 244 bytes; total agent reply (含 IRC \`__msg:\` overhead + 14-char 中文 prefix) ≈ 380 bytes < 390 limit. URL stays in one PRIVMSG.

soul.md 14-char template prevents agent from writing 30-char preambles that would push us back over the limit.

## Behavior change

- JWT field rename is wire-breaking. Pre-merge tokens become invalid after deploy. Acceptable: 180s TTL means worst case one customer needs to re-trigger.
- Existing voice.json schema unchanged.