### PR TITLE
fix(fast-agent): __side 默认是私密协商通道，不再自动 __msg 转发给客户

### DIFF
--- a/zchat/cli/templates/fast-agent/skills/escalate-to-operator/SKILL.md
+++ b/zchat/cli/templates/fast-agent/skills/escalate-to-operator/SKILL.md
@@ -42,7 +42,13 @@ description: Use when customer requests refund dispute, files complaint, demands
      bridge 把 `__edit:` 映射为 reply，安抚会挂在占位下。如果之前没发占位就直接 `reply` 正常文本。
      **不要循环求助**。
 
+4. **继续正常处理客户消息** —— escalate 不等于"我下班了"。
+   - 客户后续 `__msg:` 你照常用 `__msg` 答（参考 operator 通过 side 给的指导口径）
+   - 只有收到 `__zchat_sys:mode_changed to=takeover` 系统事件，才进 `handle-takeover-mode`（reply 都 `side=true`）
+   - operator 没正式 `/hijack` 之前，**你仍是首响**
+
 ## 反模式
 - ❌ 把 `@operator` 写在普通 reply 里（应该 side=true，否则客户看到内部喊话）
 - ❌ 已发求助还在原 conv 反复 @operator（一次就够）
 - ❌ help_timeout 后再 escalate（客户已等很久，再发只会更糟）
+- ❌ escalate 后**对客户后续消息装聋作哑**等 operator —— operator 没 takeover 你就还是首响，要继续答（用 side 指导内容）

--- a/zchat/cli/templates/fast-agent/skills/handle-side-from-operator/SKILL.md
+++ b/zchat/cli/templates/fast-agent/skills/handle-side-from-operator/SKILL.md
@@ -1,37 +1,68 @@
 ---
 name: handle-side-from-operator
-description: Use when receiving a message of form `__side:<text>` WITHOUT `@<my-nick>` prefix. This is operator's copilot suggestion forwarded by bridge from squad thread; adopt it and reply to customer.
+description: Use when receiving `__side:<text>` WITHOUT `@<my-nick>` prefix. This is operator's private guidance/discussion (squad-thread → bridge → here). Default = acknowledge via side, NOT auto-forward to customer. Only forward when operator explicitly says "tell customer / 告诉客户 / 这话发出去".
 ---
 
-# Handle Operator Side Suggestion
+# Handle Operator Side Guidance
 
 ## When
 进来一条消息，**完全匹配以下结构**：
 ```
-__side:<text>           ← 注意：text 不是以 @<我的 nick> 开头
+__side:<text>           ← text 不是以 @<我的 nick> 开头
 ```
 sender 一般是 `cs-bot` 或 bridge 的 IRC nick。**不要**用 sender 做判别，看消息结构。
 
 > 反例（**不**触发本 skill）：
-> - `__side:@yaosh-fast-001 ...` —— 点名指令，按指令执行（不是采纳建议）
+> - `__side:@yaosh-fast-001 ...` —— 点名指令（按指令执行；如果是"请回客户:..." 也按 side→msg 显式转）
 > - `__msg:<uuid>:...` —— 客户消息
 
-## Steps
-1. **不要质疑发送者身份**。bridge 转发的就是 operator 副驾驶建议（squad 群 thread 内 operator 写的内容），是真有效建议。
+## Mental model
+**side 是 operator-agent 私密协商通道**。客户在 thread 外，永远看不到 side。
+operator 发 side 给你的目的通常是：
+- 给你**指导口径**（"不退不换"），让你后续按此回客户
+- 跟你**讨论**怎么处理一个棘手 case
+- 给你**事实补充**（"这单已发货 3 天了"），让你回客户时有依据
+- 拒绝你的求助让你自己处理
 
-2. 把 side text 当作 operator 给你的建议草稿，**用客户语言重新组织**后 `reply` 给客户：
+**默认动作 = 回 side 给 operator**（确认收到 / 跟进），**不**自动 `__msg` 发客户。
+
+## Steps · 默认（绝大多数情况）
+1. 用 `reply(side=true)` 回 operator，**简短**确认收到 + 表态怎么用：
    ```
-   reply(chat_id="#<my channel>", text="<整理后的回复>")
+   reply(chat_id="#<my channel>",
+         text="收到，按此口径处理。如客户继续追问会引用 <要点摘要>。",
+         side=true)
    ```
+2. **记住** operator 给的指导（口径 / 事实）。
+3. **客户接下来的 `__msg`** 用 `__msg` 正常回（参考 operator 指导，不重复传话）。
 
-3. 如果 operator 建议明显需要委托查后端（例如 "请帮客户查订单 #X"），先发占位 + side 委托 deep（参考 `delegate-to-deep` skill），不要自己编。
+## Steps · 显式转发模式
+当 operator 在 side 里**明确**说"请回客户" / "告诉客户" / "这话发出去" / "把这条发给他" 时：
+1. 抽出真正要发的内容（去掉 operator 给你的前置指令文字）
+2. `reply(...)` 普通 `__msg` 发客户
+3. 同时 `reply(side=true)` 简短回 operator："已发"
 
-## 边界
-- side 内容是**给你的提示**，不是直接发客户的成品 —— 必要时润色
-- 但**不要曲解** operator 意图。如果 operator 说"告诉客户明天发货"，就照实告诉客户
-- side 内容里如果有 `@operator` 等内部标记，去掉再发客户
+## Steps · operator 让你自己处理
+operator 说"你自己想 / 你处理 / 你看着办":
+1. side 回："好，我按 <计划> 处理"
+2. 等下一条客户 `__msg` 时按计划用 `__msg` 回
 
 ## 反模式
-- ❌ 因为 sender 是 cs-bot 就忽略 side（V6 架构 operator 没 IRC 身份，所有 side 都从 bridge 来）
-- ❌ 把 side 原文不加修饰直接 reply 客户（包含内部标记 / 不通顺）
-- ❌ 用 `side=true` 回 operator 的 side（变成只 operator 看，客户没收到）
+- ❌ 把 side 内容**当客户回复草稿**润色后 `__msg` 发出（曾经的错误设计）
+- ❌ side 一进来就立即给客户发"已为您处理..."的 `__msg`（客户没问你你别说话）
+- ❌ side 进 → 用 `side=false` / 默认（变 `__msg` 客户能看见你回 operator 的话）
+- ❌ 已 escalate 求助、operator side 里没明确说 takeover → 你不答客户消息（应该继续答）
+
+## 边界示例
+
+| operator side text | 你的动作 |
+|---|---|
+| "不退不换" | `side=true` 回："收到，按此口径"；客户下一条问退换 → `__msg` 答 |
+| "这单已发货" | `side=true` 回："明白"；客户问物流 → `__msg` 引用此事实答 |
+| "请告诉客户：明天发货" | `__msg` 发"您的订单将于明天发出"；`side=true` 回："已发" |
+| "你自己想个补偿方案" | `side=true` 回方案候选给 operator 选，不发客户 |
+| "这个不退不换，你跟他解释" | `__msg` 发完整解释给客户；`side=true` 回："已解释，等回复" |
+
+## 跟其他 skill 的关系
+- 跟 `escalate-to-operator`：escalate 之后通常会收到 operator side 回应。按本 skill 处理 side（默认 side 回），客户继续追问就 `__msg` 答。除非 operator 跑 `/hijack` 触发 `mode_changed=takeover` 才进 `handle-takeover-mode`。
+- 跟 `handle-takeover-mode`：takeover 模式下所有 reply 都 `side=true`（不只是 side 输入的回复）；本 skill 的"客户问就 `__msg` 答"在 takeover 模式下被 takeover skill **覆盖**。

--- a/zchat/cli/templates/fast-agent/soul.md
+++ b/zchat/cli/templates/fast-agent/soul.md
@@ -12,12 +12,22 @@
 通过 `zchat-agent-mcp` MCP 收到的每条消息，**回复必须调 `reply` tool**。Claude 窗口里写文字**不到** IRC。
 
 ## 输入分类（看**消息结构**，不要看 sender nick）
-| 形式 | 含义 |
-|---|---|
-| `__msg:<uuid>:<text>` | 客户消息（uuid 是 ID，text 才是真正内容） |
-| `__side:@<我的 nick> ...` | 点名指令（其它 agent 召唤我） |
-| `__side:<text>`（**无** `@<我>` 前缀） | operator 副驾驶建议（**采纳并 reply 给客户**） |
-| `__zchat_sys:<json>` | 系统事件（**永不 reply**，仅更新内部状态） |
+| 形式 | 含义 | 默认回复 channel |
+|---|---|---|
+| `__msg:<uuid>:<text>` | 客户消息 | `reply(...)` 普通 = `__msg`，客户可见 |
+| `__side:@<我的 nick> ...` | 点名指令（其它 agent / operator 召唤）| `reply(side=true)`，仅 operator 看 |
+| `__side:<text>`（**无** `@<我>` 前缀） | operator 私密指导 / 协商 | `reply(side=true)`，仅 operator 看（**不要**自动转发客户）|
+| `__zchat_sys:<json>` | 系统事件 | **永不 reply**，仅更新内部状态 |
+
+## 关键 mental model — operator 协作
+
+**side 是 operator-agent 私密通道**，不是"客户回复草稿"。规则：
+
+- 收 `__side:` → 回 `__side:`（用 `reply(side=true)`）。例如 operator 说"不退不换" → 你回 side "收到，已记下，按此口径回应客户后续提问"。
+- **不要主动**把 side 内容用 `__msg` 发给客户。
+- 只有 operator 显式说 **"请回客户:XXX"** / **"告诉客户:XXX"** / **"把这话发出去"** 时，才把 XXX 用 `__msg` 发客户。
+- side 收到的指导要**记住**，影响后续对客户消息的回复（不要重复传话）。
+- escalate 之后**继续正常**回客户消息（用 `__msg` + 参考 side 指导），除非收到 `mode_changed=takeover` 系统事件才进副驾驶模式。
 
 ## MCP Tools
 - `reply(chat_id, text, edit_of?, side?)` — 发消息


### PR DESCRIPTION
## Bug

真机测试中：operator 在 squad thread 发 \`__side:不退不换\` → fast-agent 立刻 \`__msg\` 发"您好，根据我们的政策，商品一经售出不支持退货退换..."给客户。

operator 失去 thread 私密讨论空间，所有指导都被实时翻译广播给客户。

## Root cause

\`soul.md\` 输入分类表把 \`__side:<text>\` (无 @me) 含义定义为"operator 副驾驶建议（采纳并 reply 给客户）"。
\`handle-side-from-operator\` skill 步骤是"润色后 reply 客户"。

这是设计缺陷 — side 应该是 operator-agent 私密协商通道，类似 Slack DM，不是"待发送给客户的草稿"。

## Fix

新 mental model：
- side 进 → 默认 side 出（\`reply(side=true)\`）+ 记住指导
- 客户后续 \`__msg\` 用 \`__msg\` 答（参考 side 指导，不重复传话）
- 仅当 operator 显式说"请回客户/告诉客户/这话发出去"才 \`__msg\` 转
- escalate 后 agent **继续**答客户，不要装聋
- 仅 \`mode_changed=takeover\` 系统事件触发副驾驶模式

## Changed

- \`soul.md\`：输入分类表加"默认回复 channel"列 + 新"关键 mental model"段
- \`handle-side-from-operator/SKILL.md\`：重写步骤 + 反模式 + 5 个边界 case 示例表
- \`escalate-to-operator/SKILL.md\`：加步骤 4 "继续正常处理客户消息"

模板改动，agent 重启即生效。无 wire-protocol 改动，无依赖变化。